### PR TITLE
Refactor ready event to handle non-existent members gracefully.

### DIFF
--- a/src/events/ready.js
+++ b/src/events/ready.js
@@ -62,7 +62,10 @@ module.exports = {
                     const Guild = await client.guilds.fetch(data.Guild);
                     const member = await Guild.members.fetch(userId);
                     const roleId = '1279589654055620719';
-                    await member.roles.remove(roleId);
+
+                    // Only remove the role if user is still in the server. Else it will give an (Unknown Member) error 
+                    // as we are trying to modify a-non existent member
+                    if (member) await member.roles.remove(roleId);
 
                     data.RoleAssignments = data.RoleAssignments.filter(member => member.userId !== userId)
                     await data.save()


### PR DESCRIPTION
Problem: When a user left the guild while their id was still in the RoleAssigments array. The bot would try to modify their roles. This would give an Unknown Member as because you're trying to remove roles from a non-existent member.

Solution: Check if user is still member of guild before removing their role.